### PR TITLE
ci: fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
           node-version: lts/*
       - name: Install release dependencies
         run: |
-          npm install semantic-release@^24.0.0 \
-          @semantic-release/git@^10.0.1 semantic-release-factorio@^1.5.1 \
-          conventional-changelog-conventionalcommits-factorio@^1.1.0
+          npm install semantic-release@^24 \
+          @semantic-release/git@^10 semantic-release-factorio@^1.5.1 \
+          conventional-changelog-conventionalcommits@^8
       - name: Run semantic-release
         run: npx semantic-release
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -6,17 +6,20 @@
         [
             "@semantic-release/commit-analyzer",
             {
-                "config": "conventional-changelog-conventionalcommits-factorio",
+                "preset": "conventionalcommits",
                 "releaseRules": [
+                    { "type": "info", "release": "patch" },
                     { "type": "feat", "release": "minor" },
-                    { "type": "fix", "release": "patch" },
-                    { "type": "perf", "release": "patch" },
-                    { "type": "compat", "release": "patch" },
+                    { "type": "feature", "release": "minor" },
+                    { "type": "gui", "release": "patch" },
                     { "type": "balance", "release": "patch" },
+                    { "type": "perf", "release": "patch" },
+                    { "type": "performance", "release": "patch" },
+                    { "type": "compat", "release": "patch" },
+                    { "type": "compatibility", "release": "patch" },
+                    { "type": "fix", "release": "patch" },
                     { "type": "graphics", "release": "patch" },
                     { "type": "sound", "release": "patch" },
-                    { "type": "gui", "release": "patch" },
-                    { "type": "info", "release": "patch" },
                     { "type": "locale", "release": "patch" },
                     { "type": "translate", "release": "patch" },
                     { "type": "control", "release": "patch" },
@@ -27,7 +30,33 @@
         [
             "@semantic-release/release-notes-generator",
             {
-                "config": "conventional-changelog-conventionalcommits-factorio"
+                "preset": "conventionalcommits",
+                "writerOpts": {
+                    "headerPartial": "---------------------------------------------------------------------------------------------------\nVersion: {{version}}\nDate: {{#if date}}{{date}}{{else}}????{{/if}}\n",
+                    "footerPartial": "",
+                    "commitPartial": "{{#if scope}}[{{scope}}] {{/if}}{{~subject}}",
+                    "mainTemplate": "{{> header}}\n{{#each commitGroups}}\n  {{title}}:\n{{#each commits}}\n    - {{> commit root=@root}}\n{{/each}}\n{{/each}}"
+                },
+                "presetConfig": {
+                    "types": [
+                        { "type": "info", "section": "Info" },
+                        { "type": "feat", "section": "Features" },
+                        { "type": "feature", "section": "Features" },
+                        { "type": "gui", "section": "Gui" },
+                        { "type": "balance", "section": "Balancing" },
+                        { "type": "perf", "section": "Optimizations" },
+                        { "type": "performance", "section": "Optimizations" },
+                        { "type": "compat", "section": "Compatibility" },
+                        { "type": "compatibility", "section": "Compatibility" },
+                        { "type": "fix", "section": "Bugfixes" },
+                        { "type": "graphics", "section": "Graphics" },
+                        { "type": "sound", "section": "Sounds" },
+                        { "type": "locale", "section": "Locale" },
+                        { "type": "translate", "section": "Translation" },
+                        { "type": "control", "section": "Control" },
+                        { "type": "other", "section": "Changes" }
+                    ]
+                }
             }
         ],
         "semantic-release-factorio",


### PR DESCRIPTION
This should fix the github action for packaging and releasing

# !!! BEFORE MERGING THIS !!!

To make sure that the action generates the correct version for the next release you should make a tag called `v1.4.6` on commit 14bfc2ebaf277e92b208287ff46ff4ffd0846118

```sh
git tag -m v1.4.6 v1.4.6 14bfc2ebaf277e92b208287ff46ff4ffd0846118
git push origin v1.4.6
```

After this one tag the release action will automatically tag any future releases.